### PR TITLE
feat: add Anthropic theme with brand toggle switch

### DIFF
--- a/public/images/logos/anthropic-logo.svg
+++ b/public/images/logos/anthropic-logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 24 24"><path fill="currentColor" d="M17.304 3.541h-3.672l6.696 16.918H24Zm-10.608 0L0 20.459h3.744l1.37-3.553h7.005l1.369 3.553h3.744L10.536 3.541Zm-.371 10.223L8.616 7.82l2.291 5.945Z"/></svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,71 +7,157 @@
 
 /* Theme color constants */
 :root {
-  /* Light theme colors */
-  --light-bg: #f8f9fa; /* Soft off-white */
-  --light-fg: #343a40; /* Charcoal for better contrast */
-  --light-card: #ffffff; /* Pure white cards */
-  --light-muted: #495057; /* Darker muted */
-  --light-border: #dee2e6; /* Subtle neutral border */
-  
-  /* Alexa light theme colors */
-  --light-alexa-blue: #0088a9; /* Deeper teal blue */
-  --light-alexa-blue-dark: #006d89; /* Even deeper blue for hover states */
-  --light-alexa-secondary: #1a91c7; /* Deeper secondary blue */
-  --light-alexa-accent: #00a8cc; /* Deeper accent */
-  
-  /* Dark theme colors */
-  --dark-bg: #232F3E; /* Amazon dark blue */
-  --dark-fg: #f5f5f7; /* Light text */
-  --dark-card: #2d3a4a; /* Darker card background */
-  --dark-muted: #aeaeb2; /* Light muted */
-  --dark-border: #3d3d41; /* Dark border */
-  
-  /* Alexa dark theme colors */
-  --dark-alexa-blue: #00CAFF; /* Bright Alexa blue */
-  --dark-alexa-secondary: #31C4F3; /* Secondary blue */
-  --dark-alexa-accent: #00C8FF; /* Accent blue */
+  /* ===== ANTHROPIC BRAND COLORS ===== */
+  /* Light theme - Anthropic */
+  --anthropic-light-bg: #FAF9F7; /* Warm cream */
+  --anthropic-light-fg: #1A1915; /* Warm dark */
+  --anthropic-light-card: #FFFFFF; /* Pure white cards */
+  --anthropic-light-muted: #6B6860; /* Warm muted */
+  --anthropic-light-border: #E5E4E0; /* Warm border */
+
+  /* Anthropic light brand colors */
+  --anthropic-light-primary: #D97757; /* Coral/terracotta */
+  --anthropic-light-primary-dark: #C4684A; /* Darker coral for hover */
+  --anthropic-light-secondary: #E8947A; /* Lighter coral */
+  --anthropic-light-accent: #DA7756; /* Accent coral */
+
+  /* Dark theme - Anthropic */
+  --anthropic-dark-bg: #1A1915; /* Warm dark */
+  --anthropic-dark-fg: #FAF9F7; /* Light cream text */
+  --anthropic-dark-card: #2A2820; /* Darker warm card */
+  --anthropic-dark-muted: #A8A49C; /* Warm light muted */
+  --anthropic-dark-border: #3D3A33; /* Warm dark border */
+
+  /* Anthropic dark brand colors */
+  --anthropic-dark-primary: #E8947A; /* Brighter coral for dark mode */
+  --anthropic-dark-secondary: #F0A890; /* Light coral */
+  --anthropic-dark-accent: #E8947A; /* Accent coral */
+
+  /* ===== ALEXA BRAND COLORS ===== */
+  /* Light theme - Alexa */
+  --alexa-light-bg: #f8f9fa; /* Soft off-white */
+  --alexa-light-fg: #343a40; /* Charcoal for better contrast */
+  --alexa-light-card: #ffffff; /* Pure white cards */
+  --alexa-light-muted: #495057; /* Darker muted */
+  --alexa-light-border: #dee2e6; /* Subtle neutral border */
+
+  /* Alexa light brand colors */
+  --alexa-light-primary: #0088a9; /* Deeper teal blue */
+  --alexa-light-primary-dark: #006d89; /* Even deeper blue for hover states */
+  --alexa-light-secondary: #1a91c7; /* Deeper secondary blue */
+  --alexa-light-accent: #00a8cc; /* Deeper accent */
+
+  /* Dark theme - Alexa */
+  --alexa-dark-bg: #232F3E; /* Amazon dark blue */
+  --alexa-dark-fg: #f5f5f7; /* Light text */
+  --alexa-dark-card: #2d3a4a; /* Darker card background */
+  --alexa-dark-muted: #aeaeb2; /* Light muted */
+  --alexa-dark-border: #3d3d41; /* Dark border */
+
+  /* Alexa dark brand colors */
+  --alexa-dark-primary: #00CAFF; /* Bright Alexa blue */
+  --alexa-dark-secondary: #31C4F3; /* Secondary blue */
+  --alexa-dark-accent: #00C8FF; /* Accent blue */
 }
 
-/* Apply theme colors */
+/* ===== DEFAULT: ANTHROPIC THEME (Light) ===== */
 :root, .light {
-  --background: var(--light-bg);
-  --foreground: var(--light-fg);
-  --card-bg: var(--light-card);
-  --muted: var(--light-muted);
-  --border: var(--light-border);
-  
-  --alexa-blue: var(--light-alexa-blue);
-  --alexa-blue-dark: var(--light-alexa-blue-dark);
-  --alexa-secondary: var(--light-alexa-secondary);
-  --alexa-accent: var(--light-alexa-accent);
+  --background: var(--anthropic-light-bg);
+  --foreground: var(--anthropic-light-fg);
+  --card-bg: var(--anthropic-light-card);
+  --muted: var(--anthropic-light-muted);
+  --border: var(--anthropic-light-border);
+
+  --brand-primary: var(--anthropic-light-primary);
+  --brand-primary-dark: var(--anthropic-light-primary-dark);
+  --brand-secondary: var(--anthropic-light-secondary);
+  --brand-accent: var(--anthropic-light-accent);
+
+  /* RGB values for glow effects */
+  --brand-primary-rgb: 217, 119, 87;
 }
 
+/* ===== ANTHROPIC DARK ===== */
 .dark {
-  --background: var(--dark-bg);
-  --foreground: var(--dark-fg);
-  --card-bg: var(--dark-card);
-  --muted: var(--dark-muted);
-  --border: var(--dark-border);
-  
-  --alexa-blue: var(--dark-alexa-blue);
-  --alexa-secondary: var(--dark-alexa-secondary);
-  --alexa-accent: var(--dark-alexa-accent);
+  --background: var(--anthropic-dark-bg);
+  --foreground: var(--anthropic-dark-fg);
+  --card-bg: var(--anthropic-dark-card);
+  --muted: var(--anthropic-dark-muted);
+  --border: var(--anthropic-dark-border);
+
+  --brand-primary: var(--anthropic-dark-primary);
+  --brand-primary-dark: var(--anthropic-dark-primary);
+  --brand-secondary: var(--anthropic-dark-secondary);
+  --brand-accent: var(--anthropic-dark-accent);
+
+  /* RGB values for glow effects */
+  --brand-primary-rgb: 232, 148, 122;
+}
+
+/* ===== ALEXA BRAND LIGHT ===== */
+.brand-alexa.light, .brand-alexa:not(.dark) {
+  --background: var(--alexa-light-bg);
+  --foreground: var(--alexa-light-fg);
+  --card-bg: var(--alexa-light-card);
+  --muted: var(--alexa-light-muted);
+  --border: var(--alexa-light-border);
+
+  --brand-primary: var(--alexa-light-primary);
+  --brand-primary-dark: var(--alexa-light-primary-dark);
+  --brand-secondary: var(--alexa-light-secondary);
+  --brand-accent: var(--alexa-light-accent);
+
+  /* RGB values for glow effects */
+  --brand-primary-rgb: 0, 136, 169;
+}
+
+/* ===== ALEXA BRAND DARK ===== */
+.brand-alexa.dark {
+  --background: var(--alexa-dark-bg);
+  --foreground: var(--alexa-dark-fg);
+  --card-bg: var(--alexa-dark-card);
+  --muted: var(--alexa-dark-muted);
+  --border: var(--alexa-dark-border);
+
+  --brand-primary: var(--alexa-dark-primary);
+  --brand-primary-dark: var(--alexa-dark-primary);
+  --brand-secondary: var(--alexa-dark-secondary);
+  --brand-accent: var(--alexa-dark-accent);
+
+  /* RGB values for glow effects */
+  --brand-primary-rgb: 0, 202, 255;
 }
 
 /* For users who haven't made a choice yet, respect their system preference */
-/* Initial system preference - will be overridden by .light or .dark classes */
 @media (prefers-color-scheme: dark) {
-  :root:not(.light):not(.dark) {
-    --background: var(--dark-bg);
-    --foreground: var(--dark-fg);
-    --card-bg: var(--dark-card);
-    --muted: var(--dark-muted);
-    --border: var(--dark-border);
-    
-    --alexa-blue: var(--dark-alexa-blue);
-    --alexa-secondary: var(--dark-alexa-secondary);
-    --alexa-accent: var(--dark-alexa-accent);
+  :root:not(.light):not(.dark):not(.brand-alexa) {
+    --background: var(--anthropic-dark-bg);
+    --foreground: var(--anthropic-dark-fg);
+    --card-bg: var(--anthropic-dark-card);
+    --muted: var(--anthropic-dark-muted);
+    --border: var(--anthropic-dark-border);
+
+    --brand-primary: var(--anthropic-dark-primary);
+    --brand-primary-dark: var(--anthropic-dark-primary);
+    --brand-secondary: var(--anthropic-dark-secondary);
+    --brand-accent: var(--anthropic-dark-accent);
+
+    --brand-primary-rgb: 232, 148, 122;
+  }
+
+  :root.brand-alexa:not(.light):not(.dark) {
+    --background: var(--alexa-dark-bg);
+    --foreground: var(--alexa-dark-fg);
+    --card-bg: var(--alexa-dark-card);
+    --muted: var(--alexa-dark-muted);
+    --border: var(--alexa-dark-border);
+
+    --brand-primary: var(--alexa-dark-primary);
+    --brand-primary-dark: var(--alexa-dark-primary);
+    --brand-secondary: var(--alexa-dark-secondary);
+    --brand-accent: var(--alexa-dark-accent);
+
+    --brand-primary-rgb: 0, 202, 255;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { COMMON, ALT, META } from "@/constants/strings";
+import BrandProvider from "@/context/BrandContext";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -78,7 +79,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <BrandProvider>
+          {children}
+        </BrandProvider>
       </body>
     </html>
   );

--- a/src/components/common/SectionHeader.tsx
+++ b/src/components/common/SectionHeader.tsx
@@ -17,7 +17,7 @@ export default function SectionHeader({ title, className = "" }: SectionHeaderPr
       transition={{ duration: 0.5 }}
     >
       {title}
-      <span className="absolute -bottom-3 left-0 w-16 h-1 bg-alexa-blue"/>
+      <span className="absolute -bottom-3 left-0 w-16 h-1 bg-brand-primary"/>
     </motion.h2>
   );
 }

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -7,7 +7,7 @@ interface TagProps {
 
 export default function Tag({ text, className = "" }: TagProps): React.ReactElement {
   return (
-    <span className={`text-xs px-2 py-1 rounded-full bg-alexa-blue/10 text-alexa-blue ${className}`}>
+    <span className={`text-xs px-2 py-1 rounded-full bg-brand-primary/10 text-brand-primary ${className}`}>
       {text}
     </span>
   );

--- a/src/components/ui/brand-toggle.tsx
+++ b/src/components/ui/brand-toggle.tsx
@@ -1,43 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-
-export type Brand = "anthropic" | "alexa";
+import { useBrand } from "@/context/BrandContext";
 
 export default function BrandToggle(): React.ReactElement | null {
-  const [brand, setBrand] = useState<Brand>("anthropic");
-  const [mounted, setMounted] = useState(false);
-
-  // Initialize brand from localStorage
-  useEffect(() => {
-    setMounted(true);
-
-    const savedBrand = localStorage.getItem("brand") as Brand | null;
-    if (savedBrand && (savedBrand === "anthropic" || savedBrand === "alexa")) {
-      setBrand(savedBrand);
-    }
-  }, []);
-
-  // Apply brand changes to document
-  useEffect(() => {
-    if (!mounted) return;
-
-    const root = document.documentElement;
-
-    if (brand === "alexa") {
-      root.classList.add("brand-alexa");
-    } else {
-      root.classList.remove("brand-alexa");
-    }
-
-    localStorage.setItem("brand", brand);
-  }, [brand, mounted]);
-
-  // Toggle between brands
-  const toggleBrand = (): void => {
-    setBrand(prevBrand => prevBrand === "anthropic" ? "alexa" : "anthropic");
-  };
+  const { brand, toggleBrand, mounted } = useBrand();
 
   const iconVariants = {
     initial: { scale: 0.6, opacity: 0, rotate: 0 },
@@ -61,31 +28,7 @@ export default function BrandToggle(): React.ReactElement | null {
     >
       <AnimatePresence mode="wait" initial={false}>
         {brand === "anthropic" ? (
-          // Anthropic icon - sparkles/AI symbol
-          <motion.svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            key="anthropic-icon"
-            variants={iconVariants}
-            initial="initial"
-            animate="animate"
-            exit="exit"
-            className="text-brand-primary transition-all duration-300 group-hover:drop-shadow-[0_0_12px_rgba(var(--brand-primary-rgb),0.8)] group-hover:scale-110"
-          >
-            {/* Sparkles icon representing AI */}
-            <path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5L12 3z"/>
-            <path d="M5 19l1 3 1-3 3-1-3-1-1-3-1 3-3 1 3 1z"/>
-            <path d="M19 12l1 2.5 2.5 1-2.5 1-1 2.5-1-2.5-2.5-1 2.5-1 1-2.5z"/>
-          </motion.svg>
-        ) : (
-          // Alexa icon - voice/echo ring
+          // Show Alexa icon - click to switch to Alexa
           <motion.svg
             xmlns="http://www.w3.org/2000/svg"
             width="20"
@@ -107,6 +50,30 @@ export default function BrandToggle(): React.ReactElement | null {
             <circle cx="12" cy="12" r="3"/>
             <circle cx="12" cy="12" r="7" strokeDasharray="4 2"/>
             <circle cx="12" cy="12" r="10" strokeDasharray="2 3" opacity="0.6"/>
+          </motion.svg>
+        ) : (
+          // Show Anthropic icon - click to switch to Anthropic
+          <motion.svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            key="anthropic-icon"
+            variants={iconVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            className="text-brand-primary transition-all duration-300 group-hover:drop-shadow-[0_0_12px_rgba(var(--brand-primary-rgb),0.8)] group-hover:scale-110"
+          >
+            {/* Sparkles icon representing AI */}
+            <path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5L12 3z"/>
+            <path d="M5 19l1 3 1-3 3-1-3-1-1-3-1 3-3 1 3 1z"/>
+            <path d="M19 12l1 2.5 2.5 1-2.5 1-1 2.5-1-2.5-2.5-1 2.5-1 1-2.5z"/>
           </motion.svg>
         )}
       </AnimatePresence>

--- a/src/components/ui/brand-toggle.tsx
+++ b/src/components/ui/brand-toggle.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+
+export type Brand = "anthropic" | "alexa";
+
+export default function BrandToggle(): React.ReactElement | null {
+  const [brand, setBrand] = useState<Brand>("anthropic");
+  const [mounted, setMounted] = useState(false);
+
+  // Initialize brand from localStorage
+  useEffect(() => {
+    setMounted(true);
+
+    const savedBrand = localStorage.getItem("brand") as Brand | null;
+    if (savedBrand && (savedBrand === "anthropic" || savedBrand === "alexa")) {
+      setBrand(savedBrand);
+    }
+  }, []);
+
+  // Apply brand changes to document
+  useEffect(() => {
+    if (!mounted) return;
+
+    const root = document.documentElement;
+
+    if (brand === "alexa") {
+      root.classList.add("brand-alexa");
+    } else {
+      root.classList.remove("brand-alexa");
+    }
+
+    localStorage.setItem("brand", brand);
+  }, [brand, mounted]);
+
+  // Toggle between brands
+  const toggleBrand = (): void => {
+    setBrand(prevBrand => prevBrand === "anthropic" ? "alexa" : "anthropic");
+  };
+
+  const iconVariants = {
+    initial: { scale: 0.6, opacity: 0, rotate: 0 },
+    animate: { scale: 1, opacity: 1, rotate: 360, transition: { duration: 0.3 } },
+    exit: { scale: 0.6, opacity: 0, transition: { duration: 0.3 } }
+  };
+
+  // Don't render anything during SSR to avoid hydration mismatch
+  if (!mounted) {
+    return <div className="w-10 h-10 rounded-full flex items-center justify-center bg-transparent"/>;
+  }
+
+  return (
+    <motion.button
+      onClick={toggleBrand}
+      className="w-10 h-10 rounded-full flex items-center justify-center bg-transparent transition-colors group"
+      whileHover={{ scale: 1.1 }}
+      whileTap={{ scale: 0.9 }}
+      aria-label={`Switch to ${brand === "anthropic" ? "Alexa" : "Anthropic"} theme`}
+      title={`Currently: ${brand === "anthropic" ? "Anthropic" : "Alexa"} theme. Click to switch.`}
+    >
+      <AnimatePresence mode="wait" initial={false}>
+        {brand === "anthropic" ? (
+          // Anthropic icon - sparkles/AI symbol
+          <motion.svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            key="anthropic-icon"
+            variants={iconVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            className="text-brand-primary transition-all duration-300 group-hover:drop-shadow-[0_0_12px_rgba(var(--brand-primary-rgb),0.8)] group-hover:scale-110"
+          >
+            {/* Sparkles icon representing AI */}
+            <path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5L12 3z"/>
+            <path d="M5 19l1 3 1-3 3-1-3-1-1-3-1 3-3 1 3 1z"/>
+            <path d="M19 12l1 2.5 2.5 1-2.5 1-1 2.5-1-2.5-2.5-1 2.5-1 1-2.5z"/>
+          </motion.svg>
+        ) : (
+          // Alexa icon - voice/echo ring
+          <motion.svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            key="alexa-icon"
+            variants={iconVariants}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+            className="text-brand-primary transition-all duration-300 group-hover:drop-shadow-[0_0_12px_rgba(var(--brand-primary-rgb),0.8)] group-hover:scale-110"
+          >
+            {/* Echo/voice ring icon */}
+            <circle cx="12" cy="12" r="3"/>
+            <circle cx="12" cy="12" r="7" strokeDasharray="4 2"/>
+            <circle cx="12" cy="12" r="10" strokeDasharray="2 3" opacity="0.6"/>
+          </motion.svg>
+        )}
+      </AnimatePresence>
+    </motion.button>
+  );
+}

--- a/src/components/ui/experience.tsx
+++ b/src/components/ui/experience.tsx
@@ -21,6 +21,7 @@ export default function Experience(): React.ReactElement {
               title={exp.title}
               company={exp.company}
               logo={exp.logo}
+              logoAdaptive={exp.logoAdaptive}
               description={exp.description}
               technologies={exp.technologies}
               highlights={exp.highlights}
@@ -43,6 +44,7 @@ export default function Experience(): React.ReactElement {
               title={edu.title}
               company={edu.company}
               logo={edu.logo}
+              logoAdaptive={edu.logoAdaptive}
               description={edu.description}
               technologies={edu.technologies}
               highlights={edu.highlights}

--- a/src/components/ui/footer.tsx
+++ b/src/components/ui/footer.tsx
@@ -25,10 +25,10 @@ export default function Footer(): React.ReactElement {
 
           {/* Simplified navigation */}
           <div className="flex gap-6 mb-6">
-            <Link href={ROUTES.home} className="text-muted hover:text-alexa-blue transition-colors">{NAV.home}</Link>
-            <Link href={ROUTES.about} className="text-muted hover:text-alexa-blue transition-colors">{NAV.about}</Link>
-            <Link href={ROUTES.experience} className="text-muted hover:text-alexa-blue transition-colors">{NAV.experience}</Link>
-            <Link href={ROUTES.projects} className="text-muted hover:text-alexa-blue transition-colors">{NAV.projects}</Link>
+            <Link href={ROUTES.home} className="text-muted hover:text-brand-primary transition-colors">{NAV.home}</Link>
+            <Link href={ROUTES.about} className="text-muted hover:text-brand-primary transition-colors">{NAV.about}</Link>
+            <Link href={ROUTES.experience} className="text-muted hover:text-brand-primary transition-colors">{NAV.experience}</Link>
+            <Link href={ROUTES.projects} className="text-muted hover:text-brand-primary transition-colors">{NAV.projects}</Link>
           </div>
 
           {/* Social links with enhanced hover effects */}
@@ -37,7 +37,7 @@ export default function Footer(): React.ReactElement {
               href={SOCIAL.github}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-muted hover:text-alexa-blue hover:drop-shadow-[0_0_8px_rgba(0,202,255,0.7)] transition-colors p-1"
+              className="text-muted hover:text-brand-primary hover:drop-shadow-[0_0_8px_rgba(var(--brand-primary-rgb),0.7)] transition-colors p-1"
               aria-label={SOCIAL.platformName.github}
               whileHover={{ scale: 1.2 }}
             >
@@ -49,7 +49,7 @@ export default function Footer(): React.ReactElement {
               href={SOCIAL.linkedin}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-muted hover:text-alexa-blue hover:drop-shadow-[0_0_8px_rgba(0,202,255,0.7)] transition-colors p-1"
+              className="text-muted hover:text-brand-primary hover:drop-shadow-[0_0_8px_rgba(var(--brand-primary-rgb),0.7)] transition-colors p-1"
               aria-label={SOCIAL.platformName.linkedin}
               whileHover={{ scale: 1.2 }}
             >
@@ -64,7 +64,7 @@ export default function Footer(): React.ReactElement {
           <p className="text-sm text-muted">
             {COMMON.copyright(new Date().getFullYear())}
           </p>
-          <p className="text-xs text-muted mt-2 hover:text-alexa-blue transition-colors">
+          <p className="text-xs text-muted mt-2 hover:text-brand-primary transition-colors">
             <a
               href={COMMON.claudeUrl}
               target="_blank"

--- a/src/components/ui/hero.tsx
+++ b/src/components/ui/hero.tsx
@@ -6,7 +6,7 @@ import { COMMON, NAV } from "@/constants/strings";
 import Card from "@/components/common/Card";
 
 export default function Hero(): React.ReactElement {
-  // For Alexa voice visualization animation
+  // For voice visualization animation
   const [voiceBars, setVoiceBars] = useState<number[]>(Array(10).fill(0.3));
 
   useEffect(() => {
@@ -19,10 +19,10 @@ export default function Hero(): React.ReactElement {
 
   return (
     <section id="home" className="relative flex flex-col items-center justify-center min-h-screen px-4 py-20">
-      {/* Alexa Ring Background - Enhanced with outward animation */}
-      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[180px] h-[180px] rounded-full border-4 border-[#00CAFF]/10 z-0">
+      {/* Animated Ring Background - Enhanced with outward animation */}
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[180px] h-[180px] rounded-full border-4 border-brand-primary/10 z-0">
         <motion.div
-          className="absolute -inset-5 rounded-full border-4 border-[#00CAFF]/5 z-0"
+          className="absolute -inset-5 rounded-full border-4 border-brand-primary/5 z-0"
           animate={{
             scale: [1, 1.1, 1],
             opacity: [0.5, 0.3, 0.5],
@@ -33,11 +33,11 @@ export default function Hero(): React.ReactElement {
             ease: "easeInOut"
           }}
           style={{
-            boxShadow: "0 0 10px rgba(0, 202, 255, 0.4)"
+            boxShadow: "0 0 10px rgba(var(--brand-primary-rgb), 0.4)"
           }}
         />
         <motion.div
-          className="absolute -inset-10 rounded-full border-4 border-[#00CAFF]/3 z-0"
+          className="absolute -inset-10 rounded-full border-4 border-brand-primary/5 z-0"
           animate={{
             scale: [1, 1.15, 1],
             opacity: [0.3, 0.2, 0.3],
@@ -49,7 +49,7 @@ export default function Hero(): React.ReactElement {
             delay: 0.5
           }}
           style={{
-            boxShadow: "0 0 15px rgba(0, 202, 255, 0.3)"
+            boxShadow: "0 0 15px rgba(var(--brand-primary-rgb), 0.3)"
           }}
         />
       </div>
@@ -74,7 +74,7 @@ export default function Hero(): React.ReactElement {
         {COMMON.title}
       </Card>
 
-      {/* Alexa Voice Visualization */}
+      {/* Voice/AI Visualization */}
       <Card
         className="flex justify-center items-end gap-1 my-8 h-20 z-10"
         initial={{ opacity: 0 }}
@@ -85,7 +85,7 @@ export default function Hero(): React.ReactElement {
         {voiceBars.map((height, index) => (
           <motion.div
             key={index}
-            className="w-1 bg-alexa-blue rounded-full"
+            className="w-1 bg-brand-primary rounded-full"
             style={{ height: `${height * 100}%` }}
             animate={{ height: `${height * 100}%` }}
             transition={{ duration: 1.5, ease: "easeInOut" }}

--- a/src/components/ui/hero.tsx
+++ b/src/components/ui/hero.tsx
@@ -1,25 +1,106 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { motion } from "framer-motion";
+import { useEffect, useMemo, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { COMMON, NAV } from "@/constants/strings";
+import { useBrand } from "@/context/BrandContext";
 import Card from "@/components/common/Card";
 
-export default function Hero(): React.ReactElement {
-  // For voice visualization animation
+interface Sparkle {
+  id: number;
+  x: number;
+  y: number;
+  size: number;
+  duration: number;
+  delay: number;
+  type: "circle" | "star";
+}
+
+function generateSparkles(): Sparkle[] {
+  return Array.from({ length: 22 }, (_, i) => {
+    const angle = Math.random() * Math.PI * 2;
+    const distance = 30 + Math.random() * 120;
+    return {
+      id: i,
+      x: Math.cos(angle) * distance,
+      y: Math.sin(angle) * distance,
+      size: 3 + Math.random() * 6,
+      duration: 3 + Math.random() * 4,
+      delay: Math.random() * 2,
+      type: Math.random() > 0.5 ? "star" : "circle",
+    };
+  });
+}
+
+function AnthropicVisual(): React.ReactElement {
+  const sparkles = useMemo(() => generateSparkles(), []);
+
+  return (
+    <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[300px] h-[300px] z-0">
+      {sparkles.map((sparkle) => (
+        <motion.div
+          key={sparkle.id}
+          className="absolute top-1/2 left-1/2"
+          initial={{
+            x: sparkle.x,
+            y: sparkle.y,
+            opacity: 0,
+          }}
+          animate={{
+            x: [sparkle.x, sparkle.x + (Math.random() - 0.5) * 30, sparkle.x],
+            y: [sparkle.y, sparkle.y + (Math.random() - 0.5) * 30, sparkle.y],
+            opacity: [0.2, 0.85, 0.2],
+            scale: [0.8, 1.3, 0.8],
+          }}
+          transition={{
+            duration: sparkle.duration,
+            repeat: Infinity,
+            ease: "easeInOut",
+            delay: sparkle.delay,
+          }}
+        >
+          {sparkle.type === "star" ? (
+            <svg
+              width={sparkle.size * 3}
+              height={sparkle.size * 3}
+              viewBox="0 0 24 24"
+              fill="rgba(var(--brand-primary-rgb), 0.8)"
+              style={{
+                filter: `drop-shadow(0 0 ${sparkle.size * 1.5}px rgba(var(--brand-primary-rgb), 0.6))`,
+              }}
+            >
+              <path d="M12 2l2 6.5L20.5 12 14 14l-2 8-2-8-6.5-2L10 8.5z"/>
+            </svg>
+          ) : (
+            <div
+              className="rounded-full"
+              style={{
+                width: sparkle.size,
+                height: sparkle.size,
+                background: `rgba(var(--brand-primary-rgb), 0.7)`,
+                boxShadow: `0 0 ${sparkle.size * 3}px rgba(var(--brand-primary-rgb), 0.5)`,
+              }}
+            />
+          )}
+        </motion.div>
+      ))}
+    </div>
+  );
+}
+
+function AlexaVisual(): React.ReactElement {
   const [voiceBars, setVoiceBars] = useState<number[]>(Array(10).fill(0.3));
 
   useEffect(() => {
     const interval = setInterval(() => {
       setVoiceBars(Array(10).fill(0).map(() => Math.random() * 0.7 + 0.3));
     }, 1500);
-
     return () => clearInterval(interval);
   }, []);
 
   return (
-    <section id="home" className="relative flex flex-col items-center justify-center min-h-screen px-4 py-20">
-      {/* Animated Ring Background - Enhanced with outward animation */}
+    <>
+      {/* Animated Ring Background */}
       <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[180px] h-[180px] rounded-full border-4 border-brand-primary/10 z-0">
         <motion.div
           className="absolute -inset-5 rounded-full border-4 border-brand-primary/5 z-0"
@@ -54,6 +135,58 @@ export default function Hero(): React.ReactElement {
         />
       </div>
 
+      {/* Voice Visualization */}
+      <Card
+        className="flex justify-center items-end gap-1 my-8 h-20 z-10"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.5, delay: 0.4 }}
+        enableDefaultStyles={false}
+      >
+        {voiceBars.map((height, index) => (
+          <motion.div
+            key={index}
+            className="w-1 bg-brand-primary rounded-full"
+            style={{ height: `${height * 100}%` }}
+            animate={{ height: `${height * 100}%` }}
+            transition={{ duration: 1.5, ease: "easeInOut" }}
+          />
+        ))}
+      </Card>
+    </>
+  );
+}
+
+export default function Hero(): React.ReactElement {
+  const { brand, mounted } = useBrand();
+  const isAlexa = mounted && brand === "alexa";
+
+  return (
+    <section id="home" className="relative flex flex-col items-center justify-center min-h-screen px-4 py-20">
+      <AnimatePresence mode="wait">
+        {isAlexa ? (
+          <motion.div
+            key="alexa-visual"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.4 }}
+          >
+            <AlexaVisual/>
+          </motion.div>
+        ) : (
+          <motion.div
+            key="anthropic-visual"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.4 }}
+          >
+            <AnthropicVisual/>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       <Card
         className="text-4xl md:text-6xl lg:text-7xl font-bold text-center z-10"
         initial={{ opacity: 0, y: 20 }}
@@ -74,26 +207,7 @@ export default function Hero(): React.ReactElement {
         {COMMON.title}
       </Card>
 
-      {/* Voice/AI Visualization */}
-      <Card
-        className="flex justify-center items-end gap-1 my-8 h-20 z-10"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.5, delay: 0.4 }}
-        enableDefaultStyles={false}
-      >
-        {voiceBars.map((height, index) => (
-          <motion.div
-            key={index}
-            className="w-1 bg-brand-primary rounded-full"
-            style={{ height: `${height * 100}%` }}
-            animate={{ height: `${height * 100}%` }}
-            transition={{ duration: 1.5, ease: "easeInOut" }}
-          />
-        ))}
-      </Card>
-
-      {/* Scroll indicator instead of buttons */}
+      {/* Scroll indicator */}
       <Card
         className="absolute bottom-10 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2 text-muted"
         initial={{ opacity: 0 }}

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { motion } from "framer-motion";
 import ThemeToggle from "./theme-toggle";
+import BrandToggle from "./brand-toggle";
 import { ROUTES } from "@/constants/theme";
 import { COMMON, NAV, ALT, SOCIAL, ARIA } from "@/constants/strings";
 
@@ -67,17 +68,17 @@ export default function Navbar(): React.ReactElement {
               {NAV.projects}
             </Link>
 
-            {/* Social links with enhanced hover effects */}
+            {/* Social links and toggles */}
             <div className="flex items-center gap-3">
               <motion.a
                 href={SOCIAL.github}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-foreground/80 hover:text-alexa-blue transition-colors p-1"
+                className="text-foreground/80 hover:text-brand-primary transition-colors p-1"
                 aria-label={SOCIAL.platformName.github}
                 whileHover={{ scale: 1.2 }}
               >
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" className="hover:drop-shadow-[0_0_8px_rgba(0,202,255,0.7)]">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" className="hover:drop-shadow-[0_0_8px_rgba(var(--brand-primary-rgb),0.7)]">
                   <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
                 </svg>
               </motion.a>
@@ -85,30 +86,34 @@ export default function Navbar(): React.ReactElement {
                 href={SOCIAL.linkedin}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-foreground/80 hover:text-alexa-blue transition-colors p-1"
+                className="text-foreground/80 hover:text-brand-primary transition-colors p-1"
                 aria-label={SOCIAL.platformName.linkedin}
                 whileHover={{ scale: 1.2 }}
               >
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" className="hover:drop-shadow-[0_0_8px_rgba(0,202,255,0.7)]">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" className="hover:drop-shadow-[0_0_8px_rgba(var(--brand-primary-rgb),0.7)]">
                   <path d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854V1.146zm4.943 12.248V6.169H2.542v7.225h2.401zm-1.2-8.212c.837 0 1.358-.554 1.358-1.248-.015-.709-.52-1.248-1.342-1.248-.822 0-1.359.54-1.359 1.248 0 .694.521 1.248 1.327 1.248h.016zm4.908 8.212V9.359c0-.216.016-.432.08-.586.173-.431.568-.878 1.232-.878.869 0 1.216.662 1.216 1.634v3.865h2.401V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016a5.54 5.54 0 0 1 .016-.025V6.169h-2.4c.03.678 0 7.225 0 7.225h2.4z"/>
                 </svg>
               </motion.a>
-              <ThemeToggle/>
+              <div className="flex items-center gap-1 border-l border-border pl-3 ml-1">
+                <BrandToggle/>
+                <ThemeToggle/>
+              </div>
             </div>
           </nav>
 
           {/* Mobile Menu Button */}
-          <div className="md:hidden flex items-center gap-3">
+          <div className="md:hidden flex items-center gap-2">
+            <BrandToggle/>
             <ThemeToggle/>
             <motion.a
               href={SOCIAL.github}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-foreground/80 hover:text-alexa-blue transition-colors p-1"
+              className="text-foreground/80 hover:text-brand-primary transition-colors p-1"
               aria-label={SOCIAL.platformName.github}
               whileHover={{ scale: 1.2 }}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" className="dark:hover:drop-shadow-[0_0_8px_rgba(0,202,255,0.7)] hover:drop-shadow-[0_0_8px_rgba(0,136,169,0.7)]">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" className="hover:drop-shadow-[0_0_8px_rgba(var(--brand-primary-rgb),0.7)]">
                 <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
               </svg>
             </motion.a>
@@ -116,11 +121,11 @@ export default function Navbar(): React.ReactElement {
               href={SOCIAL.linkedin}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-foreground/80 hover:text-alexa-blue transition-colors p-1"
+              className="text-foreground/80 hover:text-brand-primary transition-colors p-1"
               aria-label={SOCIAL.platformName.linkedin}
               whileHover={{ scale: 1.2 }}
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" className="dark:hover:drop-shadow-[0_0_8px_rgba(0,202,255,0.7)] hover:drop-shadow-[0_0_8px_rgba(0,136,169,0.7)]">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" className="hover:drop-shadow-[0_0_8px_rgba(var(--brand-primary-rgb),0.7)]">
                 <path d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854V1.146zm4.943 12.248V6.169H2.542v7.225h2.401zm-1.2-8.212c.837 0 1.358-.554 1.358-1.248-.015-.709-.52-1.248-1.342-1.248-.822 0-1.359.54-1.359 1.248 0 .694.521 1.248 1.327 1.248h.016zm4.908 8.212V9.359c0-.216.016-.432.08-.586.173-.431.568-.878 1.232-.878.869 0 1.216.662 1.216 1.634v3.865h2.401V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016a5.54 5.54 0 0 1 .016-.025V6.169h-2.4c.03.678 0 7.225 0 7.225h2.4z"/>
               </svg>
             </motion.a>

--- a/src/components/ui/timeline/TimelineItem.tsx
+++ b/src/components/ui/timeline/TimelineItem.tsx
@@ -48,7 +48,7 @@ export default function TimelineItem({
       {/* Date section */}
       <div className="md:w-1/5 flex items-start">
         <div className="flex flex-col items-center md:items-end w-full">
-          <div className="font-medium text-right pr-4 border-r text-alexa-blue border-border">
+          <div className="font-medium text-right pr-4 border-r text-brand-primary border-border">
             <span>{date}</span>
           </div>
         </div>
@@ -80,15 +80,15 @@ export default function TimelineItem({
               </div>
               <Card
                 component="button"
-                className="text-sm text-alexa-blue hover:text-alexa-blue-dark transition-colors rounded-full w-6 h-6 flex items-center justify-center"
+                className="text-sm text-brand-primary hover:text-brand-primary-dark transition-colors rounded-full w-6 h-6 flex items-center justify-center"
                 aria-label={isExpanded ? "Collapse details" : "Expand details"}
                 initial={false}
                 animate={{
                   rotate: isExpanded ? 90 : 0,
-                  backgroundColor: isExpanded ? "rgba(0, 202, 255, 0.1)" : "transparent"
+                  backgroundColor: isExpanded ? "rgba(var(--brand-primary-rgb), 0.1)" : "transparent"
                 }}
                 whileHover={{
-                  backgroundColor: "rgba(0, 202, 255, 0.2)",
+                  backgroundColor: "rgba(var(--brand-primary-rgb), 0.2)",
                   scale: 1.05
                 }}
                 whileTap={{ scale: 0.95 }}

--- a/src/components/ui/timeline/TimelineItem.tsx
+++ b/src/components/ui/timeline/TimelineItem.tsx
@@ -15,6 +15,7 @@ interface TimelineItemProps {
   company: string;
   description: string;
   logo: string;
+  logoAdaptive?: boolean;
   technologies?: string[];
   highlights?: string[];
   links?: Array<{
@@ -30,6 +31,7 @@ export default function TimelineItem({
   company,
   description,
   logo,
+  logoAdaptive,
   technologies,
   highlights,
   links,
@@ -69,12 +71,18 @@ export default function TimelineItem({
             <div className="flex justify-between items-center mb-2">
               <div className="flex items-center gap-2">
                 <div className="relative w-6 h-6 flex-shrink-0">
-                  <Image
-                    src={logo}
-                    alt={`${company} logo`}
-                    fill
-                    className="object-contain"
-                  />
+                  {logoAdaptive ? (
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" className="text-foreground">
+                      <path d="M17.304 3.541h-3.672l6.696 16.918H24Zm-10.608 0L0 20.459h3.744l1.37-3.553h7.005l1.369 3.553h3.744L10.536 3.541Zm-.371 10.223L8.616 7.82l2.291 5.945Z"/>
+                    </svg>
+                  ) : (
+                    <Image
+                      src={logo}
+                      alt={`${company} logo`}
+                      fill
+                      className="object-contain"
+                    />
+                  )}
                 </div>
                 <h3 className="text-xl font-bold">{title}</h3>
               </div>

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -11,7 +11,7 @@
 // Common strings used across multiple components
 export const COMMON = {
   name: "Remi Uzel",
-  title: "Software Engineer at Anthropic",
+  title: "Member of Technical Staff at Anthropic",
   copyright: (year: number): string => `© ${year} Remi Uzel. All rights reserved.`,
   websiteUrl: "https://remuzel.github.io",
   claudeCredit: "Crafted with Claude Code",
@@ -76,10 +76,9 @@ export const ARIA = {
 // About section content
 export const ABOUT = {
   bio: [
-    "I'm a Software Engineer at Anthropic, working on building safe and beneficial AI systems.",
-    "Previously, I was a Senior Software Engineer (SDE III) at Amazon Alexa, where I led the launch of privacy-focused consent collection frameworks for european radio partners, and developed international features like Karaoke on Alexa; delighting 500k+ customers.",
+    "I'm a Member of Technical Staff at Anthropic, turning chips into thoughts.",
+    "Previously, I was a Senior Software Engineer (SDE III) at Amazon Alexa, where I accelerated Alexa+ launches across Canada and Mexico, managing multiple release programs (private Beta, Early Access, and General Availability). I also led privacy-focused consent collection frameworks for european radio partners and developed international features like Karaoke on Alexa.",
     "I hold an MEng in Mathematics and Computer Science from Imperial College London, where my Master's thesis focused on network effects by modeling ride-sharing platforms.",
-    "I want to maximise positive expectation of humanity's trajectory. My privacy compliance work has taught me that policy outcomes vary wildly, from cookie banner fatigue to genuine wins like USB-C standardization. I'm optimistic we can learn from both to develop AI governance frameworks that truly align with societal benefit.",
   ],
 }
 

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -11,7 +11,7 @@
 // Common strings used across multiple components
 export const COMMON = {
   name: "Remi Uzel",
-  title: "Senior Software Engineer at Amazon Alexa",
+  title: "Software Engineer at Anthropic",
   copyright: (year: number): string => `© ${year} Remi Uzel. All rights reserved.`,
   websiteUrl: "https://remuzel.github.io",
   claudeCredit: "Crafted with Claude Code",
@@ -76,8 +76,8 @@ export const ARIA = {
 // About section content
 export const ABOUT = {
   bio: [
-    "I'm a Senior Software Engineer (SDE III) at Amazon Alexa, currently working on transitioning customers to Alexa+.",
-    "I've led the launch of privacy-focused consent collection frameworks for european radio partners, and developed international features like Karaoke on Alexa; delighting 500k+ customers.",
+    "I'm a Software Engineer at Anthropic, working on building safe and beneficial AI systems.",
+    "Previously, I was a Senior Software Engineer (SDE III) at Amazon Alexa, where I led the launch of privacy-focused consent collection frameworks for european radio partners, and developed international features like Karaoke on Alexa; delighting 500k+ customers.",
     "I hold an MEng in Mathematics and Computer Science from Imperial College London, where my Master's thesis focused on network effects by modeling ride-sharing platforms.",
     "I want to maximise positive expectation of humanity's trajectory. My privacy compliance work has taught me that policy outcomes vary wildly, from cookie banner fatigue to genuine wins like USB-C standardization. I'm optimistic we can learn from both to develop AI governance frameworks that truly align with societal benefit.",
   ],
@@ -102,21 +102,20 @@ export const META = {
   baseUrl: "https://remuzel.github.io",
   defaultTitle: "Remi Uzel | Portfolio",
   titleTemplate: "%s | Remi Uzel",
-  description: "Portfolio of Remi Uzel, Senior Software Engineer at Amazon Alexa, specializing in backend systems, AWS cloud architecture, and distributed systems.",
+  description: "Portfolio of Remi Uzel, Software Engineer at Anthropic, specializing in AI systems, backend development, and distributed systems.",
 
   // Keywords
   keywords: [
-    "senior software engineer",
-    "AWS",
-    "Amazon",
-    "Alexa",
-    "Prime Video",
+    "software engineer",
+    "Anthropic",
+    "AI",
+    "machine learning",
+    "Claude",
     "backend engineer",
-    "java developer",
     "python developer",
     "cloud computing",
     "distributed systems",
-    "serverless"
+    "AI safety"
   ],
 
   // Open Graph
@@ -128,8 +127,8 @@ export const META = {
 
   // Theme colors
   themeColors: {
-    light: "#00CAFF",
-    dark: "#232F3E"
+    light: "#D97757",
+    dark: "#1A1915"
   },
 
   // Assets

--- a/src/context/BrandContext.tsx
+++ b/src/context/BrandContext.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { createContext, useContext, useState, useEffect } from "react";
+
+export type Brand = "anthropic" | "alexa";
+
+interface BrandContextType {
+  brand: Brand;
+  toggleBrand: () => void;
+  mounted: boolean;
+}
+
+const BrandContext = createContext<BrandContextType>({
+  brand: "anthropic",
+  toggleBrand: () => {},
+  mounted: false,
+});
+
+export function useBrand(): BrandContextType {
+  return useContext(BrandContext);
+}
+
+export default function BrandProvider({ children }: { children: React.ReactNode }): React.ReactElement {
+  const [brand, setBrand] = useState<Brand>("anthropic");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    const savedBrand = localStorage.getItem("brand") as Brand | null;
+    if (savedBrand && (savedBrand === "anthropic" || savedBrand === "alexa")) {
+      setBrand(savedBrand);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    const root = document.documentElement;
+    if (brand === "alexa") {
+      root.classList.add("brand-alexa");
+    } else {
+      root.classList.remove("brand-alexa");
+    }
+    localStorage.setItem("brand", brand);
+  }, [brand, mounted]);
+
+  const toggleBrand = (): void => {
+    setBrand(prev => prev === "anthropic" ? "alexa" : "anthropic");
+  };
+
+  return (
+    <BrandContext.Provider value={{ brand, toggleBrand, mounted }}>
+      {children}
+    </BrandContext.Provider>
+  );
+}

--- a/src/data/experiences.ts
+++ b/src/data/experiences.ts
@@ -7,6 +7,7 @@ export interface TimelineItem {
   company: string;
   description: string;
   logo: string; // Path to company logo
+  logoAdaptive?: boolean; // If true, render as inline SVG with currentColor
   technologies?: string[];
   highlights?: string[];
   links?: Array<{
@@ -21,8 +22,26 @@ export type WorkExperience = TimelineItem;
 
 export const workExperiences: WorkExperience[] = [
   {
+    id: "anthropic-mts",
+    period: "Jan 2026 - Present",
+    title: "Member of Technical Staff",
+    company: "Anthropic",
+    logo: "/images/logos/anthropic-logo.svg",
+    logoAdaptive: true,
+    description: "Turning chips into thoughts. Working on the Infrastructure (Systems) team, ensuring the compute capacity from our cloud partners is reliable and usable at scale to power Claude.",
+    technologies: ["Python", "Distributed Systems", "Cloud Infrastructure"],
+    highlights: [],
+    links: [
+      {
+        text: "Anthropic",
+        url: "https://www.anthropic.com",
+        isExternal: true
+      }
+    ]
+  },
+  {
     id: "amazon-alexa-sde-iii",
-    period: "Jul 2025 - Present",
+    period: "Jul 2025 - Jan 2026",
     title: "Senior Software Engineer - SDE III",
     company: "Amazon - Alexa",
     logo: "/images/logos/amazon-alexa.svg",
@@ -130,23 +149,6 @@ export const workExperiences: WorkExperience[] = [
       }
     ]
   },
-  {
-    id: "icl-urop",
-    period: "Jul 2018 - Aug 2018",
-    title: "Undergraduate Research Fellow",
-    company: "Imperial College London",
-    logo: "/images/logos/imperial-college-london.svg",
-    description: "Research project in Threat Modelling across human, physical & cyber vulnerabilities with Prof. Emil Lupu.",
-    technologies: ["Python", "Threat Modelling", "Wireshark", "Burp Suite"],
-    highlights: [],
-    links: [
-      {
-        text: "Prof. Emil Lupu",
-        url: "https://profiles.imperial.ac.uk/e.c.lupu/about",
-        isExternal: true
-      }
-    ]
-  }
 ];
 
 // Helper function to get all work experiences in reverse chronological order

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,13 +10,18 @@ module.exports = {
       colors: {
         'background': 'var(--background)',
         'foreground': 'var(--foreground)',
-        'alexa-blue': 'var(--alexa-blue)',
-        'alexa-blue-dark': 'var(--alexa-blue-dark)',
-        'alexa-secondary': 'var(--alexa-secondary)',
-        'alexa-accent': 'var(--alexa-accent)',
+        'brand-primary': 'var(--brand-primary)',
+        'brand-primary-dark': 'var(--brand-primary-dark)',
+        'brand-secondary': 'var(--brand-secondary)',
+        'brand-accent': 'var(--brand-accent)',
         'card-bg': 'var(--card-bg)',
         'muted': 'var(--muted)',
-        'border': 'var(--border)'
+        'border': 'var(--border)',
+        // Legacy aliases for compatibility
+        'alexa-blue': 'var(--brand-primary)',
+        'alexa-blue-dark': 'var(--brand-primary-dark)',
+        'alexa-secondary': 'var(--brand-secondary)',
+        'alexa-accent': 'var(--brand-accent)'
       },
       animation: {
         'pulse': 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',


### PR DESCRIPTION
- Add Anthropic color palette (coral/terracotta primary) alongside existing Alexa theme
- Create BrandToggle component for switching between Anthropic and Alexa themes
- Implement CSS variable system supporting both brands with light/dark modes
- Update all components to use generic brand color variables
- Replace hardcoded color values with CSS variable references
- Update strings.ts with Anthropic-related content (title, bio, meta)
- Add brand toggle to navbar (desktop and mobile views)

The brand toggle persists preference to localStorage and works
independently of the light/dark theme toggle.

https://claude.ai/code/session_01Dif7cAjowgL6vsdH6BWkmj